### PR TITLE
Add option to be prompted for devcontainer on `devcontainer exec`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,7 @@
 	
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-vscode.go"
+		"golang.go"
 	]
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ devcontainer exec vscode-remote-test-dockerfile bash
 devcontainer exec vscode-remote-test-dockercompose_devcontainer/mongo ls -a /workspaces/vscode-remote-test-dockerfile
 ```
 
+You can pass `?` as the devcontainer name and the CLI will prompt you to pick a devcontainer to run the `exec` command against, e.g.:
+
+```bash
+$ ./devcontainer exec ? bash
+Specify the devcontainer to use:
+   0: devcontainer-cli (festive_saha)
+   1: vscode-remote-test-dockerfile (fervent_gopher)
+0
+```
+
+
 ### Working with devcontainer templates
 
 To work with devcontainer templates `devcontainer` needs to know where you have the templates stored.

--- a/cmd/devcontainer/devcontainer.go
+++ b/cmd/devcontainer/devcontainer.go
@@ -66,7 +66,7 @@ func createExecCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exec DEVCONTAINER_NAME COMMAND [args...]",
 		Short: "Execute a command in a devcontainer",
-		Long:  "Execute a command in a devcontainer, similar to `docker exec`.",
+		Long:  "Execute a command in a devcontainer, similar to `docker exec`. Pass `?` as DEVCONTAINER_NAME to be prompted.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) < 2 {
@@ -80,14 +80,28 @@ func createExecCommand() *cobra.Command {
 			}
 
 			containerID := ""
-			for _, devcontainer := range devcontainers {
-				if devcontainer.ContainerName == devcontainerName || devcontainer.DevcontainerName == devcontainerName {
-					containerID = devcontainer.ContainerID
-					break
+			if devcontainerName == "?" {
+				// prompt user
+				fmt.Println("Specify the devcontainer to use:")
+				for index, devcontainer := range devcontainers {
+					fmt.Printf("%4d: %s (%s)\n", index, devcontainer.DevcontainerName, devcontainer.ContainerName)
 				}
-			}
-			if containerID == "" {
-				return cmd.Usage()
+				selection := -1
+				_, _ = fmt.Scanf("%d", &selection)
+				if selection < 0 || selection >= len(devcontainers) {
+					return fmt.Errorf("Invalid option")
+				}
+				containerID = devcontainers[selection].ContainerID
+			} else {
+				for _, devcontainer := range devcontainers {
+					if devcontainer.ContainerName == devcontainerName || devcontainer.DevcontainerName == devcontainerName {
+						containerID = devcontainer.ContainerID
+						break
+					}
+				}
+				if containerID == "" {
+					return cmd.Usage()
+				}
 			}
 
 			dockerArgs := []string{"exec", "-it", containerID}


### PR DESCRIPTION
Add the ability to pass `?` as the devcontainer name/id when running `devcontainer exec` and have the CLI prompt you to pick the devcontainer