### PR TITLE
Simplify completion for devcontainer exec

### DIFF
--- a/cmd/devcontainer/devcontainer.go
+++ b/cmd/devcontainer/devcontainer.go
@@ -136,7 +136,6 @@ func createExecCommand() *cobra.Command {
 			names := []string{}
 			for _, devcontainer := range devcontainers {
 				names = append(names, devcontainer.DevcontainerName)
-				names = append(names, devcontainer.ContainerName)
 			}
 			sort.Strings(names)
 			return names, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
Reduce completion options to devcontainer names (i.e. no longer include container names)