### PR TITLE
Add open-in-code commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,7 @@ endif
 		--workdir "${PWD}" \
 		devcontainer-cli \
 		-c "${PWD}/scripts/ci_release.sh"
+
+
+test:
+	go test -v ./...

--- a/cmd/devcontainer/main.go
+++ b/cmd/devcontainer/main.go
@@ -28,6 +28,8 @@ func main() {
 	rootCmd.AddCommand(createListCommand())
 	rootCmd.AddCommand(createTemplateCommand())
 	rootCmd.AddCommand(createUpdateCommand())
+	rootCmd.AddCommand(createOpenInCodeCommand())
+	rootCmd.AddCommand(createOpenInCodeInsidersCommand())
 	rootCmd.AddCommand(createVersionCommand())
 
 	_ = rootCmd.Execute()

--- a/cmd/devcontainer/openincode.go
+++ b/cmd/devcontainer/openincode.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"github.com/stuartleeks/devcontainer-cli/internal/pkg/devcontainers"
+	"github.com/stuartleeks/devcontainer-cli/internal/pkg/wsl"
+)
+
+func createOpenInCodeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "open-in-code <path>",
+		Short: "open the specified path devcontainer project in VS Code",
+		Long:  "Open the specified path (containing a .devcontainer folder in VS Code",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return launchDevContainer(cmd, "code", args)
+		},
+	}
+	return cmd
+}
+func createOpenInCodeInsidersCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "open-in-code-insiders <path>",
+		Short: "open the specified path devcontainer project in VS Code Insiders",
+		Long:  "Open the specified path (containing a .devcontainer folder in VS Code Insiders",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return launchDevContainer(cmd, "code-insiders", args)
+		},
+	}
+	return cmd
+}
+
+func launchDevContainer(cmd *cobra.Command, appBase string, args []string) error {
+	if len(args) != 1 {
+		return cmd.Usage()
+	}
+	path := args[0]
+
+	launchURI, err := devcontainers.GetDevContainerURI(path)
+	if err != nil {
+		return err
+	}
+	var execCmd *exec.Cmd
+	if wsl.IsWsl() {
+		execCmd = exec.Command("cmd.exe", "/C", appBase+".cmd", "--folder-uri="+launchURI)
+	} else {
+		execCmd = exec.Command(appBase, "--folder-uri="+launchURI)
+	}
+	output, err := execCmd.Output()
+	fmt.Println(string(output))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,6 @@ require (
 	github.com/rhysd/go-github-selfupdate v1.2.2
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0
+	github.com/nats-io/nats.go v1.8.1
+	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -48,6 +49,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7VjIE6z8dIvMsI4/s+1qr5EL+zoIGev1BQj1eoJ8=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
@@ -71,8 +73,13 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
+github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/gomega v1.4.2 h1:3mYCb7aPxS/RU7TI1y4rkEn1oKmPRjNJLNEXgw7MH2I=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -124,6 +131,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -156,6 +164,7 @@ golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.3.0 h1:FBSsiFRMz3LBeXIomRnVzrQwSDj4ibvcRexLG0LZGQk=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -164,8 +173,10 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/viper"
@@ -33,11 +34,14 @@ func EnsureInitialised() {
 	}
 }
 func getConfigPath() string {
+	var path string
 	if os.Getenv("HOME") != "" {
-		return "$HOME/.devcontainer-cli/"
+		path = filepath.Join("$HOME", ".devcontainer-cli/")
+	} else {
+		// if HOME not set, assume Windows and use USERPROFILE env var
+		path = filepath.Join("$USERPROFILE", ".devcontainer-cli/")
 	}
-	// if HOME not set, assume Windows and use USERPROFILE env var
-	return "$USERPROFILE/.devcontainer-cli/"
+	return os.ExpandEnv(path)
 }
 
 func GetTemplateFolders() []string {

--- a/internal/pkg/devcontainers/remoteuri.go
+++ b/internal/pkg/devcontainers/remoteuri.go
@@ -1,0 +1,81 @@
+package devcontainers
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+
+	"github.com/stuartleeks/devcontainer-cli/internal/pkg/wsl"
+)
+
+// GetDevContainerURI gets the devcontainer URI for a folder to launch using the VS Code --folder-uri switch
+func GetDevContainerURI(folderPath string) (string, error) {
+
+	absPath, err := filepath.Abs(folderPath)
+	if err != nil {
+		return "", fmt.Errorf("Error handling path %q: %s", folderPath, err)
+	}
+
+	launchPath := absPath
+	if wsl.IsWsl() {
+		var err error
+		launchPath, err = wsl.ConvertWslPathToWindowsPath(launchPath)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	launchPathHex := convertToHexString(launchPath)
+	workspaceMountPath, err := getWorkspaceMountPath(absPath)
+	if err != nil {
+		return "", err
+	}
+	uri := fmt.Sprintf("vscode-remote://dev-container+%s%s", launchPathHex, workspaceMountPath)
+
+	return uri, nil
+}
+
+func convertToHexString(input string) string {
+	return hex.EncodeToString([]byte(input))
+}
+
+// TODO: add tests (and implementation) to handle JSON parsing with comments
+// Current implementation doesn't handle
+//  - block comments
+//  - the value split on a new line from the property name
+
+func getWorkspaceMountPath(folderPath string) (string, error) {
+	// TODO - consider how to support repository-containers (https://github.com/microsoft/vscode-remote-release/issues/3218)
+
+	devcontainerDefinitionPath := filepath.Join(folderPath, ".devcontainer/devcontainer.json")
+	buf, err := ioutil.ReadFile(devcontainerDefinitionPath)
+	if err != nil {
+		return "", fmt.Errorf("Error loading devcontainer definition: %s", err)
+	}
+
+	workspaceMountPath, err := getWorkspaceMountPathFromDevcontainerDefinition(buf)
+	if err != nil {
+		return "", fmt.Errorf("Error parsing devcontainer definition: %s", err)
+	}
+	if workspaceMountPath != "" {
+		return workspaceMountPath, nil
+	}
+
+	// No `workspaceFolder` found in devcontainer.json - use default
+	_, folderName := filepath.Split(folderPath)
+	return fmt.Sprintf("/workspaces/%s", folderName), nil
+}
+
+func getWorkspaceMountPathFromDevcontainerDefinition(definition []byte) (string, error) {
+	r, err := regexp.Compile("(?m)^\\s*\"workspaceFolder\"\\s*:\\s*\"(.*)\"")
+	if err != nil {
+		return "", fmt.Errorf("Error compiling regex: %s", err)
+	}
+	matches := r.FindSubmatch(definition)
+	if len(matches) == 2 {
+		return string(matches[1]), nil
+	}
+	return "", nil
+}

--- a/internal/pkg/devcontainers/remoteuri_test.go
+++ b/internal/pkg/devcontainers/remoteuri_test.go
@@ -1,0 +1,50 @@
+package devcontainers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHexToString(t *testing.T) {
+	input := "\\\\wsl$\\Ubuntusl\\home\\stuart\\source\\kips-operator"
+	expected := "5c5c77736c245c5562756e7475736c5c686f6d655c7374756172745c736f757263655c6b6970732d6f70657261746f72"
+	actual := convertToHexString(input)
+	assert.Equal(t, expected, actual)
+}
+
+func TestGetWorkspaceFolder_withWorkspaceFolder(t *testing.T) {
+
+	content := `{
+		"someProp": 2,
+		// add a content here for good measure
+		"workspaceFolder": "/workspace/wibble",
+	}`
+	result, err := getWorkspaceMountPathFromDevcontainerDefinition([]byte(content))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "/workspace/wibble", result)
+}
+func TestGetWorkspaceFolder_withCommentedWorkspaceFolder(t *testing.T) {
+
+	content := `{
+		"someProp": 2,
+		// add a content here for good measure
+		//"workspaceFolder": "/workspace/wibble",
+	}`
+	result, err := getWorkspaceMountPathFromDevcontainerDefinition([]byte(content))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "", result)
+}
+func TestGetWorkspaceFolder_withNoWorkspaceFolder(t *testing.T) {
+
+	content := `{
+		"someProp": 2,
+		// add a content here for good measure
+	}`
+	result, err := getWorkspaceMountPathFromDevcontainerDefinition([]byte(content))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "", result)
+}

--- a/internal/pkg/wsl/wsl.go
+++ b/internal/pkg/wsl/wsl.go
@@ -1,0 +1,25 @@
+package wsl
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// IsWsl returns true if running under WSL
+func IsWsl() bool {
+	_, exists := os.LookupEnv("WSL_DISTRO_NAME")
+	return exists
+}
+
+// ConvertWslPathToWindowsPath converts a WSL path to the corresponding \\wsl$\... path for access from Windows
+func ConvertWslPathToWindowsPath(path string) (string, error) {
+	cmd := exec.Command("wslpath", "-w", path)
+
+	buf, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("Error running wslpath: %s", err)
+	}
+	return strings.TrimSpace(string(buf)), nil
+}


### PR DESCRIPTION
Add `open-in-code` and `open-in-code-insiders` commands to open a specified folder in VS Code as a devcontainer (requires the folder to have a `.devcontainer\devcontainer.json` definition