### PR TITLE
Suppress main PersistentPreRun on completion cmd

### DIFF
--- a/cmd/devcontainer/completion.go
+++ b/cmd/devcontainer/completion.go
@@ -28,6 +28,9 @@ func createCompleteCommand(rootCmd *cobra.Command) *cobra.Command {
     source <(devcontainer completion bash | sed s/devcontainer/dc/g)
 
 	`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// suppress the PersistentPreRun in main
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				_ = cmd.Usage()


### PR DESCRIPTION
Fix the intermittent `Checking: command not found` error when adding bash completion to `.bashrc` by suppressing the update check for completion commands