### PR TITLE
Set devcontainer.json name property when adding a template

### DIFF
--- a/cmd/devcontainer/template.go
+++ b/cmd/devcontainer/template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sort"
 	"text/tabwriter"
 
@@ -94,7 +95,20 @@ func createTemplateAddCommand() *cobra.Command {
 			if err = ioutil2.CopyFolder(template.Path, currentDirectory+"/.devcontainer"); err != nil {
 				return fmt.Errorf("Error copying folder: %s\n", err)
 			}
-			return err
+
+			// by default the "name" in devcontainer.json is set to the name of the template
+			// override it here with the name of the containing folder
+			devcontainerName, err := devcontainers.GetDefaultDevcontainerNameForFolder(currentDirectory)
+			if err != nil {
+				return fmt.Errorf("Error getting default devcontainer name: %s", err)
+			}
+			devcontainerJsonPath := filepath.Join(currentDirectory, ".devcontainer/devcontainer.json")
+			err = devcontainers.SetDevcontainerName(devcontainerJsonPath, devcontainerName)
+			if err != nil {
+				return fmt.Errorf("Error setting devcontainer name: %s", err)
+			}
+
+			return nil
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			// only completing the first arg  (template name)

--- a/cmd/devcontainer/template.go
+++ b/cmd/devcontainer/template.go
@@ -64,6 +64,7 @@ func createTemplateListCommand() *cobra.Command {
 }
 
 func createTemplateAddCommand() *cobra.Command {
+	var devcontainerName string
 	cmd := &cobra.Command{
 		Use:   "add TEMPLATE_NAME",
 		Short: "add devcontainer from template",
@@ -97,10 +98,12 @@ func createTemplateAddCommand() *cobra.Command {
 			}
 
 			// by default the "name" in devcontainer.json is set to the name of the template
-			// override it here with the name of the containing folder
-			devcontainerName, err := devcontainers.GetDefaultDevcontainerNameForFolder(currentDirectory)
-			if err != nil {
-				return fmt.Errorf("Error getting default devcontainer name: %s", err)
+			// override it here with the value passed in as --devcontainer-name (or the containing folder if not set)
+			if devcontainerName == "" {
+				devcontainerName, err = devcontainers.GetDefaultDevcontainerNameForFolder(currentDirectory)
+				if err != nil {
+					return fmt.Errorf("Error getting default devcontainer name: %s", err)
+				}
 			}
 			devcontainerJsonPath := filepath.Join(currentDirectory, ".devcontainer/devcontainer.json")
 			err = devcontainers.SetDevcontainerName(devcontainerJsonPath, devcontainerName)
@@ -127,6 +130,7 @@ func createTemplateAddCommand() *cobra.Command {
 			return names, cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+	cmd.Flags().StringVar(&devcontainerName, "devcontainer-name", "", "Value to set the devcontainer.json name property to (default is folder name)")
 	return cmd
 }
 

--- a/internal/pkg/devcontainers/template_test.go
+++ b/internal/pkg/devcontainers/template_test.go
@@ -1,0 +1,39 @@
+package devcontainers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetDevcontainerName(t *testing.T) {
+
+	f, err := ioutil.TempFile("", "test.json")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	f.WriteString(`{
+	"name": "initial",
+	// here's a comment!
+	"otherProperties": [
+		"something",
+		"here"
+	]
+}`)
+
+	SetDevcontainerName(f.Name(), "newName")
+
+	buf, err := ioutil.ReadFile(f.Name())
+	assert.NoError(t, err)
+
+	assert.Equal(t, `{
+	"name": "newName",
+	// here's a comment!
+	"otherProperties": [
+		"something",
+		"here"
+	]
+}`, string(buf))
+}

--- a/internal/pkg/devcontainers/template_test.go
+++ b/internal/pkg/devcontainers/template_test.go
@@ -14,7 +14,7 @@ func TestSetDevcontainerName(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
 
-	f.WriteString(`{
+	_, _ = f.WriteString(`{
 	"name": "initial",
 	// here's a comment!
 	"otherProperties": [
@@ -23,7 +23,8 @@ func TestSetDevcontainerName(t *testing.T) {
 	]
 }`)
 
-	SetDevcontainerName(f.Name(), "newName")
+	err = SetDevcontainerName(f.Name(), "newName")
+	assert.NoError(t, err)
 
 	buf, err := ioutil.ReadFile(f.Name())
 	assert.NoError(t, err)


### PR DESCRIPTION
Devcontainer templates use a standard name for the devcontainer (e.g. "python" for the python template). This PR modifies the behaviour to override the name after copying to use the name of the containing folder (or the value of the `--devcontainer-name` parameter if passed)