### PR TITLE
Set working folder for git command

### DIFF
--- a/internal/pkg/git/git.go
+++ b/internal/pkg/git/git.go
@@ -10,6 +10,7 @@ import (
 // GetTopLevelPath returns the top-level folder for the git-repo that contains path, or empty string if not a repo
 func GetTopLevelPath(path string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = path
 
 	buf, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
Fixes error running `devcontainer exec...` etc from a folder other than the root of the project containing the devcontainer