### PR TITLE
Redesign exec command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## show this help
 		| column -t -s '|'
 
 
-build: ## Build devcontainer cli
+build: fmt ## Build devcontainer cli
 	go build ./cmd/devcontainer
 
 lint: build ## Build and lint
@@ -32,3 +32,7 @@ endif
 
 test:
 	go test -v ./...
+
+
+fmt:
+	find . -name '*.go' | grep -v vendor | xargs gofmt -s -w

--- a/README.md
+++ b/README.md
@@ -51,13 +51,25 @@ For example:
 
 ```bash
 # Run an interactive bash shell in the vscode-remote-test-dockerfile devcontainer
-devcontainer exec vscode-remote-test-dockerfile bash
+devcontainer exec --name vscode-remote-test-dockerfile bash
 
 # Run a command with args in the vscode-remote-test-dockercompose_devcontainer/mongo devcontainer
-devcontainer exec vscode-remote-test-dockercompose_devcontainer/mongo ls -a /workspaces/vscode-remote-test-dockerfile
+devcontainer exec --name vscode-remote-test-dockercompose_devcontainer/mongo ls -a /workspaces/vscode-remote-test-dockerfile
+
+# Run `bash` in the dev container for the project at `~/ source/my-proj`
+devcontainer exec --path ~/source/my-proj bash
+
+# If none of --name/--path/--prompt are specified then `--path .` is assumed (i.e. use the dev container for the current directory)
+devcontainer exec bash
+
+# If command/args not set, `bash` is assumed
+devcontainer exec --name vscode-remote-test-dockerfile
+
+# Combining these to launch bash in the dev container for the project in the current directory:
+devcontainer exec
 ```
 
-You can pass `?` as the devcontainer name and the CLI will prompt you to pick a devcontainer to run the `exec` command against, e.g.:
+You can use `--prompt` instead of `--name` or `--path` and the CLI will prompt you to pick a devcontainer to run the `exec` command against, e.g.:
 
 ```bash
 $ ./devcontainer exec ? bash
@@ -74,9 +86,11 @@ You can use this with Windows Terminal profiles:
     "guid": "{4b304185-99d2-493c-940c-ae74e0f14bba}",
     "hidden": false,
     "name": "devcontainer exec",
-    "commandline": "wsl bash -c \"path/to/devcontainer exec ? bash\"",
+    "commandline": "wsl bash -c \"path/to/devcontainer exec --prompt bash\"",
 },
 ```
+
+By default, `devcontainer exec` will set the working directory to be the mount path for the dev container. This can be overridden using `--work-dir`.
 
 ### Working with devcontainer templates
 

--- a/cmd/devcontainer/devcontainer.go
+++ b/cmd/devcontainer/devcontainer.go
@@ -80,9 +80,10 @@ func createExecCommand() *cobra.Command {
 	var argDevcontainerName string
 	var argDevcontainerPath string
 	var argPromptForDevcontainer bool
+	var argWorkDir string
 
 	cmd := &cobra.Command{
-		Use:   "exec [--name <name>| --path <path> | --prompt ] [<command> [<args...>]] (command will default to /bin/bash if none provided)",
+		Use:   "exec [--name <name>| --path <path> | --prompt ] [--work-dir <work-dir>] [<command> [<args...>]] (command will default to /bin/bash if none provided)",
 		Short: "Execute a command in a devcontainer",
 		Long:  "Execute a command in a devcontainer, similar to `docker exec`",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -164,9 +165,12 @@ func createExecCommand() *cobra.Command {
 				return err
 			}
 
-			mountPath, err := devcontainers.GetWorkspaceMountPath(localPath)
-			if err != nil {
-				return err
+			mountPath := argWorkDir
+			if mountPath == "" {
+				mountPath, err = devcontainers.GetWorkspaceMountPath(localPath)
+				if err != nil {
+					return err
+				}
 			}
 
 			wslPath := localPath
@@ -204,8 +208,7 @@ func createExecCommand() *cobra.Command {
 			}
 			return nil
 		},
-		Args: cobra.ArbitraryArgs,
-		// DisableFlagParsing:    true,
+		Args:                  cobra.ArbitraryArgs,
 		DisableFlagsInUseLine: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			// only completing the first arg  (devcontainer name)
@@ -227,5 +230,6 @@ func createExecCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&argDevcontainerName, "name", "n", "", "name of dev container to exec into")
 	cmd.Flags().StringVarP(&argDevcontainerPath, "path", "", "", "path containing the dev container to exec into")
 	cmd.Flags().BoolVarP(&argPromptForDevcontainer, "prompt", "", false, "prompt for the dev container to exec into")
+	cmd.Flags().StringVarP(&argWorkDir, "work-dir", "", "", "working directory to use in the dev container")
 	return cmd
 }

--- a/cmd/devcontainer/devcontainer.go
+++ b/cmd/devcontainer/devcontainer.go
@@ -109,8 +109,7 @@ func createExecCommand() *cobra.Command {
 				return err
 			}
 			if argDevcontainerName != "" {
-				var devcontainerName string
-				devcontainerName = argDevcontainerName
+				devcontainerName := argDevcontainerName
 				for _, devcontainer := range devcontainerList {
 					if devcontainer.ContainerName == devcontainerName || devcontainer.DevcontainerName == devcontainerName {
 						containerID = devcontainer.ContainerID

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -68,6 +68,6 @@ func SaveConfig() error {
 	if err := os.MkdirAll(configPath, 0755); err != nil {
 		return err
 	}
-	configFilePath:=filepath.Join(configPath, "devcontainer-cli.json")
+	configFilePath := filepath.Join(configPath, "devcontainer-cli.json")
 	return viper.WriteConfigAs(configFilePath)
 }

--- a/internal/pkg/devcontainers/dockerutils.go
+++ b/internal/pkg/devcontainers/dockerutils.go
@@ -19,6 +19,7 @@ type DevcontainerInfo struct {
 	ContainerID      string
 	ContainerName    string
 	DevcontainerName string
+	LocalFolderPath  string
 }
 
 const (
@@ -63,6 +64,7 @@ func ListDevcontainers() ([]DevcontainerInfo, error) {
 		devcontainer := DevcontainerInfo{
 			ContainerID:      parts[listPartID],
 			ContainerName:    parts[listPartContainerName],
+			LocalFolderPath:  parts[listPartLocalFolder],
 			DevcontainerName: name,
 		}
 		devcontainers = append(devcontainers, devcontainer)


### PR DESCRIPTION
Closes #31 

Adds support for exec by path as well as dev container name and defaults to current folder
Allows working directory to be overridden