### PR TITLE
Attempt to fix: file not found on brew install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ brews:
       owner: stuartleeks
       name: homebrew-tap
     folder: Formula
+    name: devcontainer
     homepage: https://github.com/stuartleeks/devcontainer-cli
     description: CLI for working with Visual Studio Code devcontainers 
     test: |


### PR DESCRIPTION
`brew install` -> No such file or directory - devcontainer-cli

Looks like it picks up the name of the binary from the repo and it should be `devcontainer` not `devcontainer-cli`