### PR TITLE
Enable SSH key forwarding for 'devcontainer exec'

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,18 +10,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt, install packages and tools
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog nano \
+    && apt-get -y install --no-install-recommends apt-utils dialog nano sudo bsdmainutils \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git iproute2 procps lsb-release \
     # Install Release Tools
     #
     # --> RPM used by goreleaser
-    && apt install -y rpm \
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    && apt install -y rpm 
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,8 @@
 	
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"golang.go"
+		"golang.go",
+		"stuartleeks.vscode-go-by-example"
 	]
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ You can use this with Windows Terminal profiles:
 },
 ```
 
-By default, `devcontainer exec` will set the working directory to be the mount path for the dev container. This can be overridden using `--work-dir`.
+
+There are some other benefits of `devcontainer exec` compared to `docker exec`:
+- it sets the working directory to be the mount path for the dev container. This can be overridden using `--work-dir`.
+- it checks whether you have [configured a user in the dev container](https://code.visualstudio.com/docs/remote/containers-advanced#_adding-a-nonroot-user-to-your-dev-container) and uses this user for the `docker exec`.
+- it checks whether you have set up an SSH agent. If you have and VS Code detects it then VS Code will [forward key requests from the container](https://code.visualstudio.com/docs/remote/containers#_using-ssh-keys). In this scenario, `devcontainer exec` configures the exec session to also forward key requests. This enables operations against git remotes secured with SSH keys to succeed.
 
 ### Working with devcontainer templates
 


### PR DESCRIPTION
Detect SSH_AUTH_SOCK on host (indicating SSH agent is configured) and lookup the SSH_AUTH_SOCK that VS Code has configured for key forwarding to wire up for `devcontainer exec` sessions