### PR TITLE
Support running devcontainer exec from child folders of the project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,3 +63,10 @@ RUN \
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog
+
+# gh
+COPY scripts/gh.sh /tmp/
+RUN /tmp/gh.sh
+
+# symlink gh config folder
+RUN echo 'if [[ ! -d /home/vscode/.config/gh ]]; then mkdir -p /home/vscode/.config; ln -s /config/gh /home/vscode/.config/gh; fi ' >> ~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,5 +61,11 @@
 	"postCreateCommand": "make post-create",
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"mounts": [
+		// Mounts the .config/gh host folder into the dev container to pick up host gh CLI login details
+		// NOTE that mounting directly to ~/.config/gh makes ~/.config only root-writable
+		// Instead monut to another location and symlink in Dockerfile
+		"type=bind,source=${env:HOME}${env:USERPROFILE}/.config/gh,target=/config/gh",
+	],
 }

--- a/.devcontainer/scripts/gh.sh
+++ b/.devcontainer/scripts/gh.sh
@@ -1,0 +1,23 @@
+#!/bin/bash 
+set -e
+
+get_latest_release() {
+  curl --silent "https://api.github.com/repos/$1/releases/latest" |
+  grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/'
+}
+
+VERSION=${1:-"$(get_latest_release cli/cli)"}
+INSTALL_DIR=${2:-"$HOME/.local/bin"}
+CMD=gh
+NAME="GitHub CLI"
+
+echo -e "\e[34m»»» 📦 \e[32mInstalling \e[33m$NAME \e[35mv$VERSION\e[0m ..."
+
+mkdir -p $INSTALL_DIR
+curl -sSL https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_amd64.tar.gz -o /tmp/gh.tar.gz
+tar -zxvf /tmp/gh.tar.gz --strip-components 2 -C $INSTALL_DIR gh_${VERSION}_linux_amd64/bin/gh > /dev/null
+chmod +x $INSTALL_DIR/gh
+rm -rf /tmp/gh.tar.gz
+
+echo -e "\n\e[34m»»» 💾 \e[32mInstalled to: \e[33m$(which $CMD)"
+echo -e "\e[34m»»» 💡 \e[32mVersion details: \e[39m$($CMD --version)"

--- a/cmd/devcontainer/devcontainer.go
+++ b/cmd/devcontainer/devcontainer.go
@@ -142,10 +142,11 @@ func createExecCommand() *cobra.Command {
 				// TODO - update to check for devcontainers in the path ancestry
 				// Can't just check up the path for a .devcontainer folder as the container might
 				// have been created via repository containers (https://github.com/microsoft/vscode-dev-containers/tree/main/repository-containers)
-				containerID, err = devcontainers.GetContainerIDForPath(devcontainerPath)
+				devcontainer, err := devcontainers.GetClosestPathMatchForPath(devcontainerList, devcontainerPath)
 				if err != nil {
 					return err
 				}
+				containerID = devcontainer.ContainerID
 				if workDir == "" {
 					if devcontainerPath == "" {
 						workDir = "."

--- a/cmd/devcontainer/devcontainer.go
+++ b/cmd/devcontainer/devcontainer.go
@@ -111,10 +111,6 @@ func createExecCommand() *cobra.Command {
 			}
 			if argDevcontainerName != "" {
 				containerIDOrName := argDevcontainerName
-				devcontainerList, err := devcontainers.ListDevcontainers()
-				if err != nil {
-					return err
-				}
 
 				// Get container ID
 				for _, devcontainer := range devcontainerList {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bradford-hamilton/dora v0.1.1
 	github.com/kyoh86/richgo v0.3.6 // indirect
 	github.com/kyoh86/xdg v1.2.0 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/nats-io/nats.go v1.8.1
 	github.com/rhysd/go-github-selfupdate v1.2.2
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.7.0
 	github.com/wacul/ptr v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
+	golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/mattn/go-isatty v0.0.0-20170925054904-a5cdd64afdee h1:tUyoJR5V1TdXnTh
 github.com/mattn/go-isatty v0.0.0-20170925054904-a5cdd64afdee/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1yA=
+github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
@@ -190,6 +192,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b h1:qh4f65QIVFjq9eBURLEYWqaEXmOyqdUyiBSgaXWccWk=
+golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/internal/pkg/devcontainers/dockerutils_test.go
+++ b/internal/pkg/devcontainers/dockerutils_test.go
@@ -1,0 +1,49 @@
+package devcontainers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetClosestPathMatchForPath_ReturnsLongestMatch(t *testing.T) {
+
+	inputs := []DevcontainerInfo{
+		{LocalFolderPath: "/path/to/project"},
+		{LocalFolderPath: "/path/to/somewhere/else"},
+		{LocalFolderPath: "/path"},
+	}
+
+	actual, err := GetClosestPathMatchForPath(inputs, "/path/to/project")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "/path/to/project", actual.LocalFolderPath)
+	}
+}
+
+func TestGetClosestPathMatchForPath_ReturnsLongestMatchWithTrailingSlash(t *testing.T) {
+
+	inputs := []DevcontainerInfo{
+		{LocalFolderPath: "/path/to/project"},
+		{LocalFolderPath: "/path/to/somewhere/else"},
+		{LocalFolderPath: "/path"},
+	}
+
+	actual, err := GetClosestPathMatchForPath(inputs, "/path/to/project/")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "/path/to/project", actual.LocalFolderPath)
+	}
+}
+
+func TestGetClosestPathMatchForPath_ReturnsLongestMatchForChildFolder(t *testing.T) {
+
+	inputs := []DevcontainerInfo{
+		{LocalFolderPath: "/path/to/project"},
+		{LocalFolderPath: "/path/to/somewhere/else"},
+		{LocalFolderPath: "/path"},
+	}
+
+	actual, err := GetClosestPathMatchForPath(inputs, "/path/to/project/with/child")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "/path/to/project", actual.LocalFolderPath)
+	}
+}


### PR DESCRIPTION
Add support for running 

In the following example, the `project` folder contains the `.devcontainer` definition:

```
project
|- .devcontainer
|- wibble
|- ...
```

With this PR, the current working directory can be `wibble` and `devcontainer exec` will find the `project/.devcontainer` folder.
Additionally, it will default the working directory to be the `wibble` folder in the dev container


